### PR TITLE
✨ Replace view toggle with collapsible filters

### DIFF
--- a/apps/frontend/src/lib/components/leads/FilterPanel.svelte
+++ b/apps/frontend/src/lib/components/leads/FilterPanel.svelte
@@ -24,12 +24,12 @@
 
   let {
     filters = $bindable(),
-    viewMode = $bindable(),
+    filtersExpanded = $bindable(),
     leads = [],
     onReset,
   }: {
     filters: Filters;
-    viewMode: 'grid' | 'table';
+    filtersExpanded: boolean;
     leads?: Lead[];
     onReset: () => void;
   } = $props();
@@ -81,7 +81,7 @@
 
 <div class="rounded-[28px] shadow-lg p-5 space-y-3" style="background-color: #EFEAE6;">
 
-  <!-- Row 1: Search + View Toggle + Reset -->
+  <!-- Row 1: Search + Filters Toggle + Reset -->
   <div class="flex items-center gap-3">
     <div class="relative flex-1">
       <iconify-icon
@@ -105,22 +105,14 @@
         </button>
       {/if}
     </div>
-    <div class="flex items-center gap-1 bg-white rounded-2xl p-1 border border-neutral-200 h-12 flex-shrink-0">
-      <button
-        onclick={() => (viewMode = 'table')}
-        aria-label="Vue tableau"
-        class="px-3 h-full rounded-xl transition-all flex items-center justify-center {viewMode === 'table' ? 'bg-neutral-900 text-white' : 'text-neutral-500 hover:bg-neutral-100'}"
-      >
-        <iconify-icon icon="solar:list-bold" width="18"></iconify-icon>
-      </button>
-      <button
-        onclick={() => (viewMode = 'grid')}
-        aria-label="Vue grille"
-        class="px-3 h-full rounded-xl transition-all flex items-center justify-center {viewMode === 'grid' ? 'bg-neutral-900 text-white' : 'text-neutral-500 hover:bg-neutral-100'}"
-      >
-        <iconify-icon icon="solar:widget-2-bold" width="18"></iconify-icon>
-      </button>
-    </div>
+    <button
+      onclick={() => (filtersExpanded = !filtersExpanded)}
+      aria-label={filtersExpanded ? 'Masquer les filtres' : 'Afficher les filtres'}
+      class="h-12 px-4 bg-white rounded-2xl border border-neutral-200 text-neutral-600 hover:text-black hover:border-neutral-900 transition-all font-bold text-sm flex items-center gap-2 flex-shrink-0 {filtersExpanded ? 'bg-neutral-900 text-white border-neutral-900' : ''}"
+    >
+      <iconify-icon icon={filtersExpanded ? 'solar:alt-arrow-up-bold' : 'solar:filter-bold'} width="16"></iconify-icon>
+      {filtersExpanded ? 'Masquer filtres' : 'Filtres'}
+    </button>
     {#if hasActiveFilters}
       <button
         onclick={onReset}
@@ -133,6 +125,7 @@
   </div>
 
   <!-- Row 2: Lead filters -->
+  {#if filtersExpanded}
   <div class="flex flex-wrap items-start gap-4 pt-1">
 
     <!-- Status -->
@@ -394,4 +387,5 @@
     </div>
 
   </div>
+  {/if}
 </div>

--- a/apps/frontend/src/routes/app/hunts/[id]/+page.svelte
+++ b/apps/frontend/src/routes/app/hunts/[id]/+page.svelte
@@ -799,8 +799,6 @@
           </section>
         {/if}
 
-      </div>
-
         <section class="bg-white rounded-2xl border-2 border-neutral-200 overflow-hidden">
           <div class="p-8 pb-4 flex items-center gap-3">
             <div class="w-10 h-10 bg-neutral-900 rounded-xl flex items-center justify-center">

--- a/apps/frontend/src/routes/app/leads/+page.svelte
+++ b/apps/frontend/src/routes/app/leads/+page.svelte
@@ -8,7 +8,6 @@
   import FilterPanel from '$lib/components/leads/FilterPanel.svelte';
   import AuditBanner from '$lib/components/leads/AuditBanner.svelte';
   import LeadsTable from '$lib/components/leads/LeadsTable.svelte';
-  import LeadsGrid from '$lib/components/leads/LeadsGrid.svelte';
   import LeadsMap from '$lib/components/leads/LeadsMap.svelte';
   import PaginationControls from '$lib/components/leads/PaginationControls.svelte';
   import { setupAuditListeners, type AuditSession } from '$lib/websocket-events.svelte';
@@ -41,7 +40,7 @@
   });
 
   // View settings
-  let viewMode = $state<'grid' | 'table'>('table');
+  let filtersExpanded = $state(false);
 
   let mounted = false;
 
@@ -61,13 +60,11 @@
     if (filters.hasEmail) params.set('hasEmail', filters.hasEmail);
     if (sortBy !== 'createdAt') params.set('sortBy', sortBy);
     if (sortOrder !== 'desc') params.set('sortOrder', sortOrder);
-    if (viewMode !== 'table') params.set('view', viewMode);
     const qs = params.toString();
     replaceState(qs ? `?${qs}` : location.pathname, {});
   }
 
   $effect(() => {
-    viewMode;
     sortBy;
     sortOrder;
     const { search, status, contacted, country, city, businessType, category, hasWebsite, hasSocial, hasPhone, hasGps, hasEmail } = filters;
@@ -131,7 +128,6 @@
     const urlSortBy = params.get('sortBy');
     if (urlSortBy && validSortCols.includes(urlSortBy)) sortBy = urlSortBy;
     if (params.get('sortOrder') === 'asc') sortOrder = 'asc';
-    if (params.get('view') === 'grid') viewMode = 'grid';
 
     wsUnsubscribers = setupAuditListeners(
       updateAuditSession,
@@ -449,7 +445,7 @@
     {/if}
 
     <!-- Filters -->
-    <FilterPanel bind:filters bind:viewMode leads={leads} onReset={resetFilters} />
+    <FilterPanel bind:filters bind:filtersExpanded leads={leads} onReset={resetFilters} />
 
     <!-- Sort Controls -->
     <div class="flex items-center gap-2 flex-wrap">
@@ -499,10 +495,8 @@
               : 'Aucun lead disponible'}
           </p>
         </div>
-      {:else if viewMode === 'table'}
-        <LeadsTable leads={processedLeads} bind:sortBy bind:sortOrder onSort={handleSort} />
       {:else}
-        <LeadsGrid leads={processedLeads} />
+        <LeadsTable leads={processedLeads} bind:sortBy bind:sortOrder onSort={handleSort} />
       {/if}
     </div>
 


### PR DESCRIPTION
## Summary
• Removed grid/table view toggle, keeping table view only
• Added expand/collapse button for filter options
• Filters are collapsed by default for cleaner UI
• Fixed hunt detail page div structure bug

## Changes
• FilterPanel: Replaced view mode toggle with filters expand/collapse button
• Leads page: Removed LeadsGrid view, kept table view only
• Hunt detail page: Fixed extra closing div tag

## Test plan
- [x] Filters collapsed by default
- [x] Filters expand/collapse works correctly
- [x] Table view displays correctly
- [x] Build completes without errors

📊 Impact: 3 files, 16 insertions, 30 deletions
🔗 Commit: 00644cc