### PR TITLE
🐛 Fix isActive field error in team queries

### DIFF
--- a/packages/trpc/src/modules/lead/hunt/service.ts
+++ b/packages/trpc/src/modules/lead/hunt/service.ts
@@ -379,7 +379,7 @@ export default {
         team: {
           include: {
             members: {
-              where: { userId, isActive: true },
+              where: { userId },
               select: { userId: true }
             }
           }

--- a/packages/trpc/src/modules/lead/query/service.ts
+++ b/packages/trpc/src/modules/lead/query/service.ts
@@ -460,7 +460,7 @@ export default {
           team: {
             select: {
               members: {
-                where: { userId, isActive: true },
+                where: { userId },
                 select: { userId: true }
               }
             }
@@ -500,7 +500,7 @@ export default {
           team: {
             include: {
               members: {
-                where: { userId: ctx.user.id, isActive: true },
+                where: { userId: ctx.user.id },
                 select: { userId: true }
               }
             }

--- a/packages/trpc/src/modules/team/service.ts
+++ b/packages/trpc/src/modules/team/service.ts
@@ -6,7 +6,7 @@ import { TeamRole, checkTeamPermission, checkTeamMembership, isTeamOwner } from 
 export const teamService = {
   listUserTeams: async (userId: string) => {
     const memberships = await prisma.teamMember.findMany({
-      where: { userId, isActive: true },
+      where: { userId },
       include: {
         team: {
           select: {
@@ -17,9 +17,7 @@ export const teamService = {
             updatedAt: true,
             _count: {
               select: {
-                members: {
-                  where: { isActive: true }
-                },
+                members: true,
                 leads: true
               }
             }


### PR DESCRIPTION
## Summary
• Fixed critical bug causing "Unknown argument isActive" errors
• Removed non-existent isActive field from TeamMember queries
• Team member table only has: id, teamId, userId, role, joinedAt

## Changes
• listUserTeams: Removed isActive filter from where and _count
• getRunDetails: Removed isActive from members filter
• getLeadById: Removed isActive from members filter
• deleteLead: Removed isActive from members filter

## Root cause
The TeamMember table doesn't have an isActive field. I incorrectly assumed it existed when adding team scope support.

## Test plan
- [x] Teams page loads without errors
- [x] Lead detail page loads correctly
- [x] Hunt detail page works with team scope
- [x] Team member count displays correctly

📊 Impact: 3 files, 5 insertions, 7 deletions
🔗 Commit: e3f67fe